### PR TITLE
Changed to regex when parsing scf filename

### DIFF
--- a/utils/OpGen_util.py
+++ b/utils/OpGen_util.py
@@ -325,7 +325,7 @@ def _compute_assembly_stats(assembly, genomeSize):
 
 
 def _build_new_reference(assembly, minCtgLength):
-    match_expr = re.compile("(\S+).(scf|ctg).(fasta|fa)", re.IGNORECASE)
+    match_expr = re.compile("(\S+)\.(scf|ctg)\.(fasta|fa)$", re.IGNORECASE)
     new_assembly_name = os.path.basename(assembly)
     match_res = re.match(match_expr, new_assembly_name)
     try:


### PR DESCRIPTION
This is just a small change I had to make to be able to run this util. It would fail whenusing assembled fasta files with too many dots, eg. `A.Test_14_01.scf.fasta`
